### PR TITLE
Fixed metric naming

### DIFF
--- a/apps/dnn-regression/train_dnn.py
+++ b/apps/dnn-regression/train_dnn.py
@@ -71,10 +71,10 @@ def train(model_dir, training_pandas_data, test_pandas_data, label_col, feat_col
 
     print("Test RMSE:", test_rmse)
 
-    mlflow.log_param("Number of data points", len(training_pandas_data[label_col].values))
+    mlflow.log_param("num_data", len(training_pandas_data[label_col].values))
 
     #Logging the RMSE and predictions.
-    mlflow.log_metric("RMSE for test set", test_rmse)
+    mlflow.log_metric("RMSE", test_rmse)
 
     # Saving TensorFlow model.
     saved_estimator_path = regressor.export_savedmodel(model_dir, 

--- a/apps/dnn-regression/train_dnn.py
+++ b/apps/dnn-regression/train_dnn.py
@@ -71,7 +71,7 @@ def train(model_dir, training_pandas_data, test_pandas_data, label_col, feat_col
 
     print("Test RMSE:", test_rmse)
 
-    mlflow.log_param("num_data", len(training_pandas_data[label_col].values))
+    mlflow.log_param("num_train_points", len(training_pandas_data[label_col].values))
 
     #Logging the RMSE and predictions.
     mlflow.log_metric("RMSE", test_rmse)

--- a/apps/gbt-regression/train_gbt.py
+++ b/apps/gbt-regression/train_gbt.py
@@ -52,8 +52,8 @@ def train(training_pandasData, test_pandasData, label_col, feat_cols, n_trees, m
     print("Test set score:", r2_score_test)
 
     # Logging the r2 score for both sets.
-    mlflow.log_metric("R2 score for training set", r2_score_training)
-    mlflow.log_metric("R2 score for test set", r2_score_test)
+    mlflow.log_metric("R2_train", r2_score_training)
+    mlflow.log_metric("R2_test", r2_score_test)
 
     # Saving the model as an artifact.
     sklearn.log_model(xgbr, "model")

--- a/apps/linear-regression/train_linear.py
+++ b/apps/linear-regression/train_linear.py
@@ -49,8 +49,8 @@ def train(training_pandas_data, test_pandas_data, label_col,
     print("Test set score:", r2_score_test)
 
     #Logging the r2 score for both sets.
-    mlflow.log_metric("R2 score for training set", r2_score_training)
-    mlflow.log_metric("R2 score for test set", r2_score_test)
+    mlflow.log_metric("R2_train", r2_score_training)
+    mlflow.log_metric("R2_test", r2_score_test)
 
     #Saving the model as an artifact.
     sklearn.log_model(en, "model")


### PR DESCRIPTION
New MLflow update broke the tests because names of metric were invalid - this PR fixes them